### PR TITLE
relocated server creds to .env file and added a REDAME.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Vercel Deployment Service
+
+
+
+## ```.env``` setup 
+
+Before running the services locally make sure to add this ```.env``` file and content init .
+
+```/vercel-deploy-service```
+```bash
+AWS_ACCESS_KEY=YOUR_ACCESS_KEY
+
+AWS_SECRET_ACCESS_KEY=YOUR_ACCESS_KEY
+
+CLOUDFLARE_STORAGE_ENDPOINT=YOUR_ENDPOINT_URL
+```
+
+```/vercel-upload-service```  & ```/vercel-request-handler```
+```bash
+AWS_ACCESS_KEY=YOUR_ACCESS_KEY
+
+AWS_SECRET_ACCESS_KEY=YOUR_ACCESS_KEY
+
+CLOUDFLARE_STORAGE_ENDPOINT=YOUR_ENDPOINT_URL
+
+PORT=YOUR_PREFFERED_PORT_NO
+```
+
+

--- a/vercel-deploy-service/.gitignore
+++ b/vercel-deploy-service/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/vercel-deploy-service/package-lock.json
+++ b/vercel-deploy-service/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "^20.11.16",
         "@types/redis": "^4.0.11",
         "aws-sdk": "^2.1553.0",
+        "dotenv": "^16.4.1",
         "fs": "^0.0.1-security",
         "path": "^0.12.7",
         "redis": "^4.6.13"
@@ -184,6 +185,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/es-errors": {

--- a/vercel-deploy-service/package.json
+++ b/vercel-deploy-service/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^20.11.16",
     "@types/redis": "^4.0.11",
     "aws-sdk": "^2.1553.0",
+    "dotenv": "^16.4.1",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
     "redis": "^4.6.13"

--- a/vercel-deploy-service/src/aws.ts
+++ b/vercel-deploy-service/src/aws.ts
@@ -1,11 +1,14 @@
 import { S3 } from "aws-sdk";
 import fs from "fs";
 import path from "path";
+require("dotenv").config()
+
+const {AWS_ACCESS_KEY,AWS_SECRET_ACCESS_KEY,CLOUDFLARE_STORAGE_ENDPOINT,PORT} = process.env
 
 const s3 = new S3({
-    accessKeyId: "7ea9c3f8c7f0f26f0d21c5ce99d1ad6a",
-    secretAccessKey: "b4df203781dd711223ce931a2d7ca269cdbf81bb530de4548474584951b798be",
-    endpoint: "https://e21220f4758c0870ba9c388712d42ef2.r2.cloudflarestorage.com"
+    accessKeyId: AWS_ACCESS_KEY,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    endpoint: CLOUDFLARE_STORAGE_ENDPOINT
 })
 
 // output/asdasd

--- a/vercel-request-handler/.gitignore
+++ b/vercel-request-handler/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/vercel-request-handler/package-lock.json
+++ b/vercel-request-handler/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/express": "^4.17.21",
         "aws-sdk": "^2.1553.0",
+        "dotenv": "^16.4.1",
         "express": "^4.18.2"
       }
     },
@@ -294,6 +295,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ee-first": {

--- a/vercel-request-handler/package.json
+++ b/vercel-request-handler/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@types/express": "^4.17.21",
     "aws-sdk": "^2.1553.0",
+    "dotenv": "^16.4.1",
     "express": "^4.18.2"
   }
 }

--- a/vercel-request-handler/src/index.ts
+++ b/vercel-request-handler/src/index.ts
@@ -1,10 +1,13 @@
 import express from "express";
 import { S3 } from "aws-sdk";
+require("dotenv").config()
+
+const {AWS_ACCESS_KEY,AWS_SECRET_ACCESS_KEY,CLOUDFLARE_STORAGE_ENDPOINT,PORT} = process.env
 
 const s3 = new S3({
-    accessKeyId: "7ea9c3f8c7f0f26f0d21c5ce99d1ad6a",
-    secretAccessKey: "b4df203781dd711223ce931a2d7ca269cdbf81bb530de4548474584951b798be",
-    endpoint: "https://e21220f4758c0870ba9c388712d42ef2.r2.cloudflarestorage.com"
+    accessKeyId: AWS_ACCESS_KEY,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    endpoint: CLOUDFLARE_STORAGE_ENDPOINT
 })
 
 const app = express();
@@ -27,4 +30,6 @@ app.get("/*", async (req, res) => {
     res.send(contents.Body);
 })
 
-app.listen(3001);
+app.listen(PORT, () => {
+    console.log(`Server listening on PORT : ${PORT}`);
+  });

--- a/vercel-upload-service/.gitignore
+++ b/vercel-upload-service/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env

--- a/vercel-upload-service/package-lock.json
+++ b/vercel-upload-service/package-lock.json
@@ -13,6 +13,7 @@
         "@types/express": "^4.17.21",
         "aws-sdk": "^2.1553.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.1",
         "express": "^4.18.2",
         "redis": "^4.6.13",
         "simple-git": "^3.22.0"
@@ -413,6 +414,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ee-first": {

--- a/vercel-upload-service/package.json
+++ b/vercel-upload-service/package.json
@@ -14,6 +14,7 @@
     "@types/express": "^4.17.21",
     "aws-sdk": "^2.1553.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "redis": "^4.6.13",
     "simple-git": "^3.22.0"

--- a/vercel-upload-service/src/aws.ts
+++ b/vercel-upload-service/src/aws.ts
@@ -1,10 +1,13 @@
 import { S3 } from "aws-sdk";
 import fs from "fs";
+require("dotenv").config()
+
+const {AWS_ACCESS_KEY,AWS_SECRET_ACCESS_KEY,CLOUDFLARE_STORAGE_ENDPOINT,PORT} = process.env
 
 const s3 = new S3({
-    accessKeyId: "7ea9c3f8c7f0f26f0d21c5ce99d1ad6a",
-    secretAccessKey: "b4df203781dd711223ce931a2d7ca269cdbf81bb530de4548474584951b798be",
-    endpoint: "https://e21220f4758c0870ba9c388712d42ef2.r2.cloudflarestorage.com"
+    accessKeyId: AWS_ACCESS_KEY,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    endpoint: CLOUDFLARE_STORAGE_ENDPOINT
 })
 
 // fileName => output/12312/src/App.jsx

--- a/vercel-upload-service/src/index.ts
+++ b/vercel-upload-service/src/index.ts
@@ -7,6 +7,8 @@ import { getAllFiles } from "./file";
 import path from "path";
 import { uploadFile } from "./aws";
 import { createClient } from "redis";
+require("dotenv").config()
+const {PORT} = process.env;
 const publisher = createClient();
 publisher.connect();
 
@@ -48,4 +50,4 @@ app.get("/status", async (req, res) => {
     })
 })
 
-app.listen(3000);
+app.listen(PORT);


### PR DESCRIPTION
Upon reviewing the source code of this project, it was noted that AWS credentials were openly declared within the codebase. To enhance security practices, these credentials have been relocated to a `.env` file. Additionally, a `README.md` file has been included to streamline the setup process for new developers.