### PR TITLE
Removed Async Await With forEach

### DIFF
--- a/vercel-upload-service/src/index.ts
+++ b/vercel-upload-service/src/index.ts
@@ -24,11 +24,9 @@ app.post("/deploy", async (req, res) => {
 
     const files = getAllFiles(path.join(__dirname, `output/${id}`));
 
-    files.forEach(async file => {
-        await uploadFile(file.slice(__dirname.length + 1), file);
-    })
+    const uploadPromises = files.map((file) => uploadFile(file.slice(__dirname.length + 1), file));
+    Promise.all(uploadPromises);
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
     publisher.lPush("build-queue", id);
     // INSERT => SQL
     // .create => 


### PR DESCRIPTION
forEach accepts a callback function. Hence, async await won't work.